### PR TITLE
Simplify changes protocol

### DIFF
--- a/functions/changes/index.js
+++ b/functions/changes/index.js
@@ -8,10 +8,47 @@ const {
 } = require("osm-replication-streams");
 const osm2obj = require('osm2obj');
 const stringify = require("stringify-stream");
+const through2 = require("through2");
 
 const checkpointStream = require('./lib/checkpoint-stream');
 
 const STREAM_NAME = env.require("STREAM_NAME");
+
+/**
+ * A simplified protocol of the osm2obj format omits
+ * the action property of each OSM entity and attaches
+ * the visible property following these rules:
+ * 
+ * 1. If the action is a create, then visible=true because
+ * a created entity is a visible entity with version=1
+ * 2. If the action is a modify, then visible=true with a 
+ * version > 1
+ * 3. If the action is a delete, then visible=false
+ * 
+ * @param {Object} obj - An osm2obj object
+ * @returns {Object} A simplified object
+ * 
+ */
+function obj2simple (obj) {
+  let res = {};
+
+  // Omit the action
+  for (var prop in obj) {
+    if (prop !== 'action') {
+      res[prop] = obj[prop];
+    }
+  }
+
+  if (obj['action']) {
+    if (obj['action'] === 'create' || obj['action'] === 'modify') {
+      res['visible'] = 'true';
+    }
+    else {
+      res['visible'] = 'false';
+    }
+  }
+  return res;
+}
 
 exports.handle = (event, context, callback) =>
   checkpointStream(Changes, (err, stream) => {
@@ -22,6 +59,11 @@ exports.handle = (event, context, callback) =>
 
     stream
       .pipe(osm2obj())
+      .pipe(through2.obj(function (obj, enc, cb) {
+        const res = obj2simple(obj);
+        this.push(res);
+        cb();
+      }))
       .pipe(stringify())
       .pipe(new Kinesis(STREAM_NAME));
   });

--- a/functions/changes/index.js
+++ b/functions/changes/index.js
@@ -29,7 +29,7 @@ const STREAM_NAME = env.require("STREAM_NAME");
  * @returns {Object} A simplified object
  * 
  */
-function obj2simple (obj) {
+const obj2simple = obj => {
   let res = {};
 
   // Omit the action
@@ -40,15 +40,12 @@ function obj2simple (obj) {
   }
 
   if (obj['action']) {
-    if (obj['action'] === 'create' || obj['action'] === 'modify') {
-      res['visible'] = 'true';
-    }
-    else {
-      res['visible'] = 'false';
-    }
+    res.visible = ['create', 'modify'].includes(obj['action']);
   }
   return res;
 }
+
+
 
 exports.handle = (event, context, callback) =>
   checkpointStream(Changes, (err, stream) => {
@@ -59,10 +56,8 @@ exports.handle = (event, context, callback) =>
 
     stream
       .pipe(osm2obj())
-      .pipe(through2.obj(function (obj, enc, cb) {
-        const res = obj2simple(obj);
-        this.push(res);
-        cb();
+      .pipe(through2.obj((obj, enc, cb) => {
+        cb(null, obj2simple(obj));
       }))
       .pipe(stringify())
       .pipe(new Kinesis(STREAM_NAME));

--- a/functions/changes/package-lock.json
+++ b/functions/changes/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "changes-json",
+  "name": "changes",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -391,6 +391,15 @@
         }
       }
     },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -435,6 +444,11 @@
       "requires": {
         "lodash": "4.17.4"
       }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     }
   }
 }

--- a/functions/changes/package.json
+++ b/functions/changes/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "changes-json",
+  "name": "changes",
   "version": "1.0.0",
   "description": "",
   "author": "Seth Fitzsimmons <seth@mojodna.net>",
@@ -11,6 +11,7 @@
     "osm-replication-streams": "^0.1.1",
     "osm2obj": "^2.2.2",
     "require-env": "^0.2.1",
-    "stringify-stream": "^1.0.5"
+    "stringify-stream": "^1.0.5",
+    "through2": "^2.0.3"
   }
 }


### PR DESCRIPTION
We can simplify the changes protocol emitted by osm2obj by removing the action attribute and adding a visible attribute:

If an OSM entity is 
a) created, it is visible=true with a version=1
b) modified, it is visible=true with a version>1
d) deleted, it is visible=false